### PR TITLE
Star size validation fix

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -94,7 +94,7 @@ form:
       append: px
       validate:
         type: number
-        min: 5
+        min: 1
 
     use_full_stars:
       type: toggle


### PR DESCRIPTION
There is no way to set real star size cause of type of field is text and min length is 5 by default